### PR TITLE
[Scenario] Add notes field to activities, decisions

### DIFF
--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ActivityComponent.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ActivityComponent.java
@@ -124,6 +124,9 @@ public class ActivityComponent extends CostFunctionComponent implements Duration
 		PropertyDescriptor comm = new PropertyDescriptor("Comm (Kb/s)", 
 				new CommPropertyEditor(this),  VisualControlDescriptor.TextField);
 		comm.setFieldMutable(true);
+		PropertyDescriptor notes = new PropertyDescriptor("Notes", 
+				new NotesPropertyEditor(this),  VisualControlDescriptor.TextArea);
+		notes.setFieldMutable(true);
 
 		fields.add(type);
 		fields.add(startTime);
@@ -131,6 +134,7 @@ public class ActivityComponent extends CostFunctionComponent implements Duration
 		fields.add(duration);
 		fields.add(power);
 		fields.add(comm);
+		fields.add(notes);
 
 		return fields;
 	}

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ActivityData.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ActivityData.java
@@ -18,6 +18,7 @@ public class ActivityData {
 	private double power;
 	private double comm;
 	private String type;
+	private String notes;
 	private Date startDate;
 	private Date endDate;
 
@@ -54,6 +55,14 @@ public class ActivityData {
 	
 	public void setActivityType(String type) {
 		this.type = type;
+	}
+	
+	public String getNotes() {
+		return notes != null ? notes : ""; // Never return null
+	}
+	
+	public void setNotes(String notes) {
+		this.notes = notes;
 	}
 
 	public Date getStartTime() {

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/DecisionComponent.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/DecisionComponent.java
@@ -91,10 +91,14 @@ public class DecisionComponent extends AbstractComponent implements DurationCapa
 		PropertyDescriptor duration = new PropertyDescriptor("Duration",
 				new TimePropertyEditor(this, TimeProperty.DURATION), VisualControlDescriptor.TextField);
 		duration.setFieldMutable(true);
+		PropertyDescriptor notes = new PropertyDescriptor("Notes", 
+				new NotesPropertyEditor(this),  VisualControlDescriptor.TextArea);
+		notes.setFieldMutable(true);
 		
 		fields.add(startTime);
 		fields.add(endTime);
 		fields.add(duration);
+		fields.add(notes);
 
 		return fields;
 	}

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/DecisionData.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/DecisionData.java
@@ -16,6 +16,7 @@ public class DecisionData {
 
 	private Date startDate;
 	private Date endDate;
+	private String notes;
 
 	public Date getStartTime() {
 		return startDate;
@@ -31,6 +32,13 @@ public class DecisionData {
 
 	public void setEndDate(Date endDate) {
 		this.endDate = endDate;
+	}	
+	
+	public String getNotes() {
+		return notes != null ? notes : ""; // Never return null
 	}
 	
+	public void setNotes(String notes) {
+		this.notes = notes;
+	}
 }

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/NotesPropertyEditor.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/NotesPropertyEditor.java
@@ -1,0 +1,69 @@
+package gov.nasa.arc.mct.scenario.component;
+import gov.nasa.arc.mct.components.AbstractComponent;
+import gov.nasa.arc.mct.components.PropertyEditor;
+
+import java.util.List;
+
+
+/**
+ * Property editor to add notes to either an activity or a decision
+ *
+ */
+public final class NotesPropertyEditor implements PropertyEditor<Object> {
+
+	private AbstractComponent component = null;
+
+	public NotesPropertyEditor(AbstractComponent component) {
+		this.component = component;
+		if (!(component instanceof ActivityComponent) && !(component instanceof DecisionComponent)) {
+			throw new IllegalArgumentException("NotesPropertyEditor only valid for activities and decisions");
+		}
+	}
+
+	
+	@Override
+	public String getAsText() {
+		if (component instanceof ActivityComponent) {
+			return ((ActivityComponent) component).getModel().getData().getNotes();
+		} else if (component instanceof DecisionComponent) {
+			return ((DecisionComponent) component).getModel().getData().getNotes();
+		} else {
+			return "";
+		}
+	}
+
+	/**
+	 * Set and save the value in the business model.
+	 * 
+	 * @param newValue the new value
+	 * @throws exception if the new value is invalid.  MCT platform will handle this exception and
+	 * disallow the prospective edit.
+	 */
+	@Override
+	public void setAsText(String newValue) throws IllegalArgumentException {
+		if (newValue == null) {
+			throw new IllegalArgumentException("Cannot be null");
+		}
+		if (component instanceof ActivityComponent) {
+			((ActivityComponent) component).getModel().getData().setNotes(newValue);
+		} else if (component instanceof DecisionComponent) {
+			((DecisionComponent) component).getModel().getData().setNotes(newValue);
+		}			
+	}
+
+	@Override
+	public String getValue() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setValue(Object selection) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<Object> getTags() {
+		throw new UnsupportedOperationException();
+	}
+} 
+


### PR DESCRIPTION
Satisfies nasa/MCT-Plugins#32. Adds a 'notes' field to both
activities and decisions. This allows arbitrary multi-line
text to be attached to these objects, for purposes of
explanation, description, et cetera.
