### PR TITLE
[Scenario] Track revision when building distribution

### DIFF
--- a/scenario-assembly/src/dist.xml
+++ b/scenario-assembly/src/dist.xml
@@ -14,7 +14,13 @@
     		<outputDirectory>resources/properties</outputDirectory>
     		<destName>persistence.properties</destName>
     		<fileMode>0777</fileMode>
-    	</file>
+    	</file>    	  
+    	<file>
+	      <source>src/main/resources/properties/scenario.properties</source>
+	      <outputDirectory>resources/properties</outputDirectory>
+	      <filtered>true</filtered>
+	      <fileMode>0777</fileMode>
+	    </file>
     </files>
     <fileSets>
     	<fileSet>
@@ -35,7 +41,7 @@
     		<directory>src/main/resources</directory>
     		<outputDirectory>resources</outputDirectory>
    			<includes>
-   				<include>properties/mct.properties</include>
+   				<include>properties/mct.properties</include>   				
    			</includes>
     		<fileMode>0777</fileMode>
     		<directoryMode>0777</directoryMode>

--- a/scenario-assembly/src/main/resources/properties/scenario.properties
+++ b/scenario-assembly/src/main/resources/properties/scenario.properties
@@ -1,0 +1,4 @@
+# Easiest way to set revision is to invoke maven with
+# -Dscenario.revision=`git rev-parse HEAD`
+scenario.revision=${scenario.revision}
+


### PR DESCRIPTION
This permits easier correlation of scenario builds to specific code state by recording commit hash to scenario.properties
