### PR TITLE
[Scenario] Fix comparator in TimelineView

### DIFF
--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineView.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineView.java
@@ -308,7 +308,7 @@ public class TimelineView extends AbstractTimelineView {
 			public int compare(DurationCapability a, DurationCapability b) {
 				long diff = (a.getStart() - b.getStart());				
 				// Diff could conceivably be more than MAX_INT, so reduce to 1 or -1
-				return (int) (diff / Math.abs(diff));
+				return (int) (Math.signum((double)diff));
 			}
 		});
 		


### PR DESCRIPTION
Previously introduced sorting of nested Activities
in TimelineView to detect situations where they
overlapped. Comparator used for this sort included
a possible divide-by-zero; replaced by Math.signum
here.
