### PR TITLE
[Scenario] Archive to zip for deployment

### DIFF
--- a/scenario-assembly/src/dist.xml
+++ b/scenario-assembly/src/dist.xml
@@ -5,7 +5,7 @@
     
     <id>dist</id>
     <formats>
-        <format>tar.gz</format>
+        <format>zip</format>
     </formats>
     <includeBaseDirectory>true</includeBaseDirectory>
     <files>


### PR DESCRIPTION
Change archive format from tar.gz to zip,
since the latter is easier for Windows users
to deal with.
