### PR TITLE
[Scenario] Auto-update timeline view

### DIFF
--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineMergeHandler.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineMergeHandler.java
@@ -82,11 +82,12 @@ public class TimelineMergeHandler {
 	 * (as observed during the constructor call).
 	 * @param otherParent the component to which unsaved changes will be transferred
 	 */
-	public void update(AbstractComponent otherParent) {
-		update(otherParent, new HashSet<String>());
+	public boolean update(AbstractComponent otherParent) {
+		return update(otherParent, new HashSet<String>());
 	}
 	
-	private void update(AbstractComponent component, Set<String> ignore) {
+	private boolean update(AbstractComponent component, Set<String> ignore) {
+		boolean updated = false;
 		String id = component.getComponentId();
 		if (!ignore.contains(id)) {
 			ignore.add(id);
@@ -106,13 +107,18 @@ public class TimelineMergeHandler {
 						clean.setStart(dirty.getStart());
 						clean.setEnd(dirty.getEnd());						
 					}
+					// Make sure the component still appears dirty
+					component.save();
+					// Report that we did update a component
+					updated = true;
 				}
 			}
 			
 			// Visit children
 			for (AbstractComponent child : component.getComponents()) {
-				update(child, ignore);
+				updated |= update(child, ignore);
 			}
 		}
+		return updated;
 	}
 }

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineView.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineView.java
@@ -79,9 +79,13 @@ public class TimelineView extends AbstractTimelineView implements TimelineContex
                     AbstractComponent committedComponent = 
                     		PlatformAccess.getPlatform().getPersistenceProvider().getComponent(getManifestedComponent().getComponentId());
                     // Propogate unsaved changes to the newer component
-                    new TimelineMergeHandler(getManifestedComponent()).update(committedComponent);
+                    boolean updated = new TimelineMergeHandler(getManifestedComponent()).update(committedComponent);
                     setManifestedComponent(committedComponent);
+                    updateMasterDuration();
                     rebuildUpperPanel();
+                    if (updated) {
+                    	save();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Per nasa/MCT-Plugins#56, Timeline View is a special case
where the normal rules for stale views (which do not update 
to reflect model changes initiated from other views until the 
user explicitly requests this) should not apply. Specifically, 
the user is interested in composing these timelines and
wants changes made in the Browse area to show up right 
away.

This change addresses this use case by:
- Listening for object staleness among all activities in a timeline view, and re-creating the inner part of the view based on the latest from persistence when staleness is observed.
- Taking a snapshot of unsaved changes to activities within the timeline (specifically, their start and end times) and re-applying them to the new versions being loaded from persistence (so that the user doesn't lose their unsaved changes)

The handling of unsaved changing is a limited example of component merging, nasa/mct#174. There are likely to be cases where this behaves undesirably due to the current inability to determine what has changed in a given component - for instance, a component whose BDN has been changed in the timeline inspector will not receive updates to start/end times based on staleness, but will have its BDN erased. Although other alternatives might provide desired behavior more often, some cases like this will still exist until nasa/mct#174 is addressed (alternately, any solution which resolve all of these cases would be a solution to nasa/mct#174)
