### PR TITLE
[Scenario] Validate times entered via info view

### DIFF
--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/TimePropertyEditor.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/TimePropertyEditor.java
@@ -78,15 +78,24 @@ public class TimePropertyEditor implements PropertyEditor<Object> {
 			return 0;
 		}
 		
-		private void setTime(DurationCapability dc, long time) {
+		private void setTime(DurationCapability dc, long time) throws IllegalArgumentException {
 			switch (this) {
 			case START:
+				if (time > dc.getEnd() || time < 0) {
+					throw new IllegalArgumentException("Invalid start time.");
+				}
 				dc.setStart(time);
 				break;
 			case END:
+				if (time < dc.getStart() || time < 0) {
+					throw new IllegalArgumentException("Invalid end time.");
+				}
 				dc.setEnd(time);
 				break;
 			case DURATION:
+				if (time < 0) {
+					throw new IllegalArgumentException("Invalid duration.");
+				}
 				dc.setEnd(dc.getStart() + time);
 				break;				
 			}


### PR DESCRIPTION
Ensure that start, end, and duration times entered
for an Activity or Decision via the Info View are
valid with respect to other times set for that
object. Specifically, disallow start times that
happen after end times, and disallow any negative
times (times less than zero).
