### PR TITLE
[Scenario] Remove usage of deprecated icon API

### DIFF
--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/api/NewActivityAction.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/api/NewActivityAction.java
@@ -27,7 +27,6 @@ import java.awt.event.ActionEvent;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.ResourceBundle;
 import java.util.Set;
 
 import javax.swing.JFrame;
@@ -51,7 +50,7 @@ public class NewActivityAction extends ContextAwareAction {
 	private static final long serialVersionUID = -2933386263765070857L;
 	private static final Logger logger = LoggerFactory.getLogger(NewActivityAction.class);
 	private Collection<View> selectedManifestations;
-	private static ResourceBundle bundle = ResourceBundle.getBundle("Bundle");
+	//private static ResourceBundle bundle = ResourceBundle.getBundle("Bundle");
     
     private String graphicsDeviceName;
 

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ScenarioPluginProvider.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ScenarioPluginProvider.java
@@ -29,11 +29,15 @@ import gov.nasa.arc.mct.scenario.view.TimelineInspector;
 import gov.nasa.arc.mct.scenario.view.TimelineView;
 import gov.nasa.arc.mct.services.component.AbstractComponentProvider;
 import gov.nasa.arc.mct.services.component.ComponentTypeInfo;
+import gov.nasa.arc.mct.services.component.CreateWizardUI;
+import gov.nasa.arc.mct.services.component.TypeInfo;
 import gov.nasa.arc.mct.services.component.ViewInfo;
 import gov.nasa.arc.mct.services.component.ViewType;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.ResourceBundle;
 
 import javax.swing.ImageIcon;
@@ -53,29 +57,25 @@ public class ScenarioPluginProvider extends AbstractComponentProvider {
 			bundle.getString("display_name_activity"),  
 			bundle.getString("description_activity"), 
 			ActivityComponent.class,
-			new ActivityCreationWizardUI(),
-			new ImageIcon(ScenarioPluginProvider.class.getResource("/icons/mct_icon_activity.png")));
+			true);
 
 	private static final ComponentTypeInfo decisionComponentType = new ComponentTypeInfo(
 			bundle.getString("display_name_decision"),  
 			bundle.getString("description_decision"), 
 			DecisionComponent.class,
-			new DecisionCreationWizardUI(),
-			new ImageIcon(ScenarioPluginProvider.class.getResource("/icons/mct_icon_decision.png")));
+			true);
 
 	private static final ComponentTypeInfo timelineComponentType = new ComponentTypeInfo(
 			bundle.getString("display_name_timeline"),  
 			bundle.getString("description_timeline"), 
 			TimelineComponent.class,
-			true,
-			new ImageIcon(ScenarioPluginProvider.class.getResource("/icons/mct_icon_timeline.png")));
+			true);
 
 	private static final ComponentTypeInfo scenarioComponentType = new ComponentTypeInfo(
 			bundle.getString("display_name_scenario"),  
 			bundle.getString("description_scenario"), 
 			ScenarioComponent.class,
-			true,
-			new ImageIcon(ScenarioPluginProvider.class.getResource("/icons/mct_icon_scenario.png")));
+			true);
 	
 	
 	private static final PolicyInfo timelineViewPolicy = new PolicyInfo(
@@ -85,6 +85,20 @@ public class ScenarioPluginProvider extends AbstractComponentProvider {
 	private static final PolicyInfo containmentPolicy = new PolicyInfo(
 			PolicyInfo.CategoryType.COMPOSITION_POLICY_CATEGORY.getKey(), 
 			ScenarioContainmentPolicy.class);
+	
+	
+	private Map<Class<?>, ImageIcon> iconMap = new HashMap<Class<?>, ImageIcon>();
+	
+	public ScenarioPluginProvider() {
+		iconMap.put(ActivityComponent.class, 
+				new ImageIcon(ScenarioPluginProvider.class.getResource("/icons/mct_icon_activity.png")));
+		iconMap.put(DecisionComponent.class, 
+				new ImageIcon(ScenarioPluginProvider.class.getResource("/icons/mct_icon_decision.png")));
+		iconMap.put(TimelineComponent.class, 
+				new ImageIcon(ScenarioPluginProvider.class.getResource("/icons/mct_icon_timeline.png")));
+		iconMap.put(ScenarioComponent.class, 
+				new ImageIcon(ScenarioPluginProvider.class.getResource("/icons/mct_icon_scenario.png")));
+	}
 	
 	@Override
 	public Collection<ComponentTypeInfo> getComponentTypes() {
@@ -116,5 +130,31 @@ public class ScenarioPluginProvider extends AbstractComponentProvider {
 				timelineViewPolicy, containmentPolicy
 				);
 	}
+
+	@Override
+	public <T> T getAsset(TypeInfo<?> type, Class<T> assetClass) {
+		// Create wizards
+		if (assetClass.isAssignableFrom(CreateWizardUI.class)) {
+			if (ActivityComponent.class.isAssignableFrom(type.getTypeClass())) {
+				return assetClass.cast(new ActivityCreationWizardUI());
+			}
+			if (DecisionComponent.class.isAssignableFrom(type.getTypeClass())) {
+				return assetClass.cast(new DecisionCreationWizardUI());
+			}
+		}
+		
+		// Icons
+		if (assetClass.isAssignableFrom(ImageIcon.class)) {
+			Class<?> typeClass = type.getTypeClass();
+			if (iconMap.containsKey(typeClass)) {
+				return assetClass.cast(iconMap.get(typeClass));
+			}
+		}
+	
+		// Default behavior
+		return super.getAsset(type, assetClass);
+	}
+
+
 	
 }

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/AbstractTimelineView.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/AbstractTimelineView.java
@@ -27,8 +27,6 @@ import gov.nasa.arc.mct.gui.View;
 import gov.nasa.arc.mct.scenario.component.DurationCapability;
 import gov.nasa.arc.mct.services.component.ViewInfo;
 
-import java.awt.Component;
-import java.awt.Container;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/LabelView.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/LabelView.java
@@ -26,6 +26,7 @@ import gov.nasa.arc.mct.gui.View;
 import gov.nasa.arc.mct.gui.ViewRoleSelection;
 import gov.nasa.arc.mct.services.component.ViewInfo;
 import gov.nasa.arc.mct.services.component.ViewType;
+import gov.nasa.arc.mct.util.MCTIcons;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -36,6 +37,7 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 
 import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
@@ -59,7 +61,7 @@ public class LabelView extends View {
 	    String name = getManifestedComponent().getDisplayName();
 	    nameLabel = new JLabel(name.length() <= MAX_NAME_LENGTH ? name : name.substring(0, MAX_NAME_LENGTH - ELLIPSES.length()) + ELLIPSES);
 	    nameLabel.setToolTipText(name);
-	    final JLabel icon = new JLabel(ac.getIcon());
+	    final JLabel icon = new JLabel(MCTIcons.processIcon(ac.getAsset(ImageIcon.class)));
 	    setOpaque(false);
 	    add(icon, BorderLayout.WEST);
         add(nameLabel, BorderLayout.CENTER);

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineDurationController.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineDurationController.java
@@ -23,7 +23,6 @@ package gov.nasa.arc.mct.scenario.view;
 
 
 import gov.nasa.arc.mct.gui.View;
-import gov.nasa.arc.mct.scenario.component.ActivityComponent;
 import gov.nasa.arc.mct.scenario.component.DurationCapability;
 import gov.nasa.arc.mct.scenario.component.DurationConstraintSystem;
 
@@ -42,7 +41,6 @@ import java.util.Map;
 public class TimelineDurationController extends MouseAdapter {
 	private static final int MINIMUM_PIXEL_WIDTH = 4;
 	
-	private ActivityComponent parentComponent = null;
 	private DurationCapability durationCapability; 
 	private AbstractTimelineView parentView;
 	
@@ -52,7 +50,6 @@ public class TimelineDurationController extends MouseAdapter {
 	private int            initialX     = 0;
 	private long           initialStart = 0;
 	private long           initialEnd   = 0;
-	private int            priorX       = 0;
 	
 	
 	public TimelineDurationController(DurationCapability dc,
@@ -94,7 +91,6 @@ public class TimelineDurationController extends MouseAdapter {
 		if (src instanceof Component) {
 			Component comp = (Component) src;
 			initialX = e.getXOnScreen();
-			priorX = initialX;
 			initialStart = durationCapability.getStart();
 			initialEnd = durationCapability.getEnd();
 			activeHandle = handles.get(comp.getCursor().getType());
@@ -182,10 +178,6 @@ public class TimelineDurationController extends MouseAdapter {
 				((Component) src).validate();
 				((Component) src).repaint();
 			}			
-			 
-			//parentView.save();
-
-			priorX = e.getXOnScreen();
 		}
 	}
 

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineInspector.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineInspector.java
@@ -29,6 +29,7 @@ import gov.nasa.arc.mct.gui.ViewRoleSelection;
 import gov.nasa.arc.mct.services.component.ViewInfo;
 import gov.nasa.arc.mct.services.component.ViewType;
 import gov.nasa.arc.mct.util.LafColor;
+import gov.nasa.arc.mct.util.MCTIcons;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -45,6 +46,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Collection;
 
+import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -136,7 +138,7 @@ public class TimelineInspector extends View {
             viewTitle.setTransferHandler(null);
             content = emptyPanel;
         } else {
-            viewTitle.setIcon(view.getManifestedComponent().getIcon());
+            viewTitle.setIcon(MCTIcons.processIcon(view.getInfo().getAsset(ImageIcon.class)));
             viewTitle.setText(view.getManifestedComponent().getDisplayName() + DASH + view.getInfo().getViewName() + PANEL_SPECIFIC);
             viewTitle.setTransferHandler(new WidgetTransferHandler());
             Collection<ViewInfo> viewInfos = view.getManifestedComponent().getViewInfos(ViewType.OBJECT);


### PR DESCRIPTION
Removes references to deprecated approach to
communicating component type icons, and
implements getAsset.

This resolves build errors related to
deprecation and keeps up-to-date with
platform API.

Also does miscellaneous clean up for 
other warnings (unused import, 
unused variables/fields.)
