### PR TITLE
[SatTrack] Removing unused includes

### DIFF
--- a/satelliteTracker/build.properties
+++ b/satelliteTracker/build.properties
@@ -22,7 +22,6 @@
 output.. = bin/
 bin.includes = META-INF/,\
                src/main/resources/OSGI-INF/component.xml,\
-               lib/joda-time-2.3.jar,\
                lib/JSatTrak.jar
 src.includes = src/main/resources/
 


### PR DESCRIPTION
Based on VWoeltjen's comments on pull-request #76, we removed the unused JodaTime reference.
