### PR TITLE
[Scenario] Use CostCapability in Activity Type repository

### DIFF
--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/CostRepositoryComponent.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/CostRepositoryComponent.java
@@ -48,7 +48,7 @@ public class CostRepositoryComponent extends AbstractComponent implements Reposi
 	
 	@Override
 	public Class<?> getCapabilityClass() {
-		return CostFunctionCapability.class;
+		return CostCapability.class;
 	}
 
 	// TODO: Use this to support the Group capability

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ScenarioPluginProvider.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ScenarioPluginProvider.java
@@ -200,7 +200,7 @@ public class ScenarioPluginProvider extends AbstractComponentProvider {
 				Map<Class<?>, ComponentTypeInfo> types = 
 						new HashMap<Class<?>, ComponentTypeInfo>();
 				types.put(TagCapability.class, tagComponentType);
-				types.put(CostFunctionCapability.class, activityTypeComponentType);
+				types.put(CostCapability.class, activityTypeComponentType);
 				return assetClass.cast(new CompositeActivityVisualControl(types));
 			} else if (ActivityTypeComponent.class.isAssignableFrom(type.getTypeClass())) {
 				return assetClass.cast(new LinkVisualControl());


### PR DESCRIPTION
Repositories implemented for Activity Types and Tags
used capabilities to determine eligibility for object
containment. Fix for nasa/MCT-Plugins#119 split
existing CostFunctionCapability to add CostCapability
(which has no notion of change over time) which
was used by Activity Types. This broke some
functionality related to Activity Type repositories,
which is restored here by updating references
to the new capability type.
