### PR TITLE
[Scenario] Scroll vertically in timeline area only

### DIFF
--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/AbstractTimelineView.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/AbstractTimelineView.java
@@ -122,6 +122,15 @@ public abstract class AbstractTimelineView extends View implements ChangeListene
 	}
 	
 	/**
+	 * Get the pixel position of the specified time point
+	 * @return
+	 */
+	public int getPixelPosition(long time) {
+		double px = getPixelScale() * (time - getTimeOffset());
+		return (int) px + getLeftPadding();
+	}
+	
+	/**
 	 * Get the number of pixels used for padding on the left-hand side.
 	 * This, in conjunction with getPixelScale() and getTimeOffset() allows 
 	 * easy conversion from X values to Time values, and vice versa.

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/GraphView.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/GraphView.java
@@ -110,6 +110,8 @@ public class GraphView extends AbstractTimelineView {
 		public void paintComponent(Graphics g) {
 			super.paintComponent(g);
 			
+			int rightX = getPixelPosition(getEnd());
+			
 			// TODO: Updating may too much computation to do every frame
 			//if (getWidth() != cachedWidth) {
 				updateGraph();
@@ -134,13 +136,13 @@ public class GraphView extends AbstractTimelineView {
 			int charHeight = getFontMetrics(getFont()).getHeight();
 			if (x.length > 1 && x.length == y.length) {
 				for (int i = 0; i < x.length - 1; i++) {
-					if (x[i] >= getLeftPadding() && x[i+1] <= getWidth() - getRightPadding()) {
+					if (x[i] >= getLeftPadding() && x[i+1] <= rightX) {
 						g.drawLine(x[i], y[i], x[i+1], y[i]);
 						g.drawLine(x[i+1], y[i], x[i+1], y[i+1]);
 							
 						double maxValue = Math.max(dataPoints[i], dataPoints[i+1]);
 						double minValue = Math.min(dataPoints[i], dataPoints[i+1]);
-						if (maxValue != minValue && x[i+1] > getLeftPadding() && x[i+1] < getWidth() - getRightPadding()) {
+						if (maxValue != minValue && x[i+1] > getLeftPadding() && x[i+1] < rightX) {
 							int maxY = Math.min(y[i], y[i+1]);
 							int minY = Math.max(y[i], y[i+1]);
 							String maxValueString = FORMAT.format(maxValue);
@@ -166,7 +168,7 @@ public class GraphView extends AbstractTimelineView {
 			String units = cost.getUnits();
 			g.setFont(getFont().deriveFont(Font.BOLD));
 			g.drawString(units, getLeftPadding() - getFontMetrics(getFont()).charsWidth(units.toCharArray(), 0, units.length()) - 8, GRAPH_PAD + GRAPH_HEIGHT /2 + charHeight / 2);
-			g.drawString(name, getWidth() - getRightPadding() - getFontMetrics(getFont()).charsWidth(name.toCharArray(), 0, name.length()), GRAPH_PAD + GRAPH_HEIGHT - 2);
+			g.drawString(name, rightX - getFontMetrics(getFont()).charsWidth(name.toCharArray(), 0, name.length()), GRAPH_PAD + GRAPH_HEIGHT - 2);
 		}
 		
 		private int toX(long t) {

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineLocalControls.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineLocalControls.java
@@ -251,7 +251,9 @@ public class TimelineLocalControls extends JPanel implements DurationCapability,
 		
 		overlay.setVisible(false);
 		
-		return new JScrollPane(midPanel);
+		JComponent pane = new JScrollPane(midPanel);
+		pane.setBorder(BorderFactory.createEmptyBorder());
+		return pane;
 	}
 	
 	private JComponent makeUpperPanel() {

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineView.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineView.java
@@ -295,7 +295,7 @@ public class TimelineView extends AbstractTimelineView implements TimelineContex
 		
 		public void paintComponent(Graphics g) {
 			super.paintComponent(g);
-			g.drawLine(getLeftPadding(), getHeight()-1, getWidth() - getRightPadding(), getHeight()-1);
+			g.drawLine(getPixelPosition(getStart()), getHeight()-1, getPixelPosition(getEnd()), getHeight()-1);
 		}
 	}
 


### PR DESCRIPTION
Satisfy nasa/MCT-Plugins#114 by introducing a scroll bar to the center area of timeline/scenario views, such that local controls for pan and zoom (as well as tick marks) are always visible.
