### PR TITLE
[Scenario] Fix bug in expand/collapse

### DIFF
--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineLocalControls.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/TimelineLocalControls.java
@@ -205,6 +205,14 @@ public class TimelineLocalControls extends JPanel implements DurationCapability,
 		}
 		
 		boolean isTopLevelControl = newParent == null && isVisible;
+		
+		// Determine if the component needs to be rebuilt by 
+		// comparing to its current state. To avoid explicit 
+		// state tracking, this is inferred from component 
+		// count. (A top-level display will have three 
+		// children, including top and bottom control areas; 
+		// other displays will only have one, the content
+		// area.)
 		int componentCount = getComponentCount();
 		boolean hasChanged = componentCount == 0 ||
 				componentCount != (isTopLevelControl ? 3 : 1);


### PR DESCRIPTION
Fixes issues around expanding/collapsing timelines in a scenario (nasa/MCT-Plugins#145)
- Reflect proper pan/zoom characteristics in nested timeline-like components by:
  - Tracking visibility (so hidden, nested timeline-like components do not get "confused" into thinking they are top-level components which should control areas)
  - Firing change events to notify children when the top-level control has changed, so they know to accept the updated pan/zoom (necessary due to the layers of nesting in these components, e.g. graph in a timeline in a scenario). 
- Additionally, void flashing extra control areas (top and bottom bars with pan/zoom controls) by keeping more careful track of which components actually need to be added (that is, more carefully tracking when a timeline-like view is "actually" at the top-level, and should provide pan/zoom controls)
