### PR TITLE
[Scenario] Use scroll panes in Activity Type dialog

### DIFF
--- a/scenario-assembly/pom.xml
+++ b/scenario-assembly/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>mct-scenario</artifactId>
   <packaging>pom</packaging>
   <name>MCT Packaging for Scenario Evaluation</name>
-  <version>${mct.platform.version}.2</version>
+  <version>${mct.platform.version}.3</version>
   
   <properties>
     <platform.relativePath>../../mct</platform.relativePath>

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/TagSelectionDialog.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/TagSelectionDialog.java
@@ -44,6 +44,7 @@ import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 
 /**
  * Check box dialog for specifying which tags (or activity types) 
@@ -176,7 +177,11 @@ public class TagSelectionDialog extends JDialog {
 		rigid.add(Box.createRigidArea(new Dimension(240,1)));		
 		
 		p.setAlignmentX(CENTER_ALIGNMENT);
-		return p;
+		
+		JScrollPane pane = new JScrollPane();
+		pane.getViewport().add(p);
+		
+		return pane;
 	}
 
 	private class Selector implements ActionListener {


### PR DESCRIPTION
Use scroll panes in dialog for choosing Activity Types
and Tags, to avoid issues where scale of list becomes
unusable (nasa/MCT-Plugins#169)
