### PR TITLE
[Scenario] avoid negative Comm value & none NPE when viewing Scenario

### DIFF
--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ScenarioComponent.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/ScenarioComponent.java
@@ -51,6 +51,9 @@ public class ScenarioComponent extends CostFunctionComponent implements Duration
 		if (capability.isAssignableFrom(ScenarioCSVExportCapability.class)) {
 			return capability.cast(new ScenarioCSVExportCapability(this));
 		}
+		if (capability.isAssignableFrom(GraphViewCapability.class)) {
+			return capability.cast(new LegacyGraphData(this));
+		}
 		if (capability.isAssignableFrom(ModelStatePersistence.class)) {
 		    JAXBModelStatePersistence<ActivityModelRole> persistence = new JAXBModelStatePersistence<ActivityModelRole>() {
 

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/TimelineComponent.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/component/TimelineComponent.java
@@ -409,7 +409,8 @@ public class TimelineComponent extends CostFunctionComponent implements Duration
 					data.put(t, currentValue);
 					double commValue = commCost.getValue(t);
 					double increase = ((i < size - 1) ? commValue * (time[i + 1] - t) / SECOND_TO_MILLIS : 0.0);
-					currentValue += increase;	
+					currentValue += increase;
+					if (currentValue < 0) currentValue = 0;
 				}
 				
 				// init starting and ending point

--- a/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/GraphView.java
+++ b/scenario/src/main/java/gov/nasa/arc/mct/scenario/view/GraphView.java
@@ -194,11 +194,11 @@ public class GraphView extends AbstractTimelineView {
 			Collection<Double> dataCollection = new ArrayList<Double>();
 			
 			Map<Long, Double> values = graphData.getData(type, isInstantaneous);
-			if (values != null) {
+			if (values != null) {								
 				dataCollection = values.values();
 				timeCollection = values.keySet();
 			}
-			
+					
 			int size = timeCollection.size();						
 			if (size > 1) {
 				Double[] dataType = new Double[] {};


### PR DESCRIPTION
According to user’s feedback, data buffer should never fall below zero. 
Enable ScenarioComponent to support GraphViewCapability. 
